### PR TITLE
Fix typo in Block_backup

### DIFF
--- a/src/Block_backup.java
+++ b/src/Block_backup.java
@@ -140,7 +140,7 @@ public class Block_backup {
 				}
 				break;
 			default:
-				System.out.println("Unknow how to rotate.");
+                                System.out.println("Unknown how to rotate.");
 				break;
 		}
 	}


### PR DESCRIPTION
## Summary
- fix a typo in `Block_backup.java` log message

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6847b2b6fc50832992eabad2fe51ceb7