### PR TITLE
Add update override to Tetris

### DIFF
--- a/src/Tetris.java
+++ b/src/Tetris.java
@@ -77,6 +77,10 @@ public class Tetris extends JFrame {
 	public void paint(Graphics g) {
 		g.drawImage(bufferScreen, 3, 25, this);
 	}
+	
+	public void update(Graphics g) {
+		paint(g);
+	}
 
 	public void stop() {
 		Thread.interrupted();		


### PR DESCRIPTION
## Summary
- avoid default `Frame` background erase by overriding `update`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847d3b9b1a88329b01e6db26a25040c