### PR TITLE
Use color constants for tetrominoes

### DIFF
--- a/src/Panel.java
+++ b/src/Panel.java
@@ -44,37 +44,37 @@ public class Panel extends JPanel {
 					drawBrick(offScreen, i, j, Color.WHITE);
 				}
 
-				/*switch( arrBoard[i][j] ) {
-					case -1:
-						drawBrick(offScreen, i, j, Color.GRAY);
-						break;
-					case 0:
-						break;
-					case 1:
-						drawBrick(offScreen, i, j, Color.YELLOW);
-						break;
-					case 2:
-						drawBrick(offScreen, i, j, Color.RED);
-						break;
-					case 3:
-						drawBrick(offScreen, i, j, Color.CYAN);
-						break;
-					case 4:
-						drawBrick(offScreen, i, j, Color.GREEN);
-						break;
-					case 5:
-						drawBrick(offScreen, i, j, Color.BLUE);
-						break;
-					case 6:
-						drawBrick(offScreen, i, j, Color.MAGENTA);
-						break;
-					case 7:
-						drawBrick(offScreen, i, j, Color.PINK);
-						break;
-					default:
-						drawBrick(offScreen, i, j, Color.LIGHT_GRAY);
-						break;
-				}*/
+                                /*switch( arrBoard[i][j] ) {
+                                        case -1:
+                                                drawBrick(offScreen, i, j, Color.GRAY);
+                                                break;
+                                        case 0:
+                                                break;
+                                        case TetrominoColor.YELLOW:
+                                                drawBrick(offScreen, i, j, Color.YELLOW);
+                                                break;
+                                        case TetrominoColor.RED:
+                                                drawBrick(offScreen, i, j, Color.RED);
+                                                break;
+                                        case TetrominoColor.CYAN:
+                                                drawBrick(offScreen, i, j, Color.CYAN);
+                                                break;
+                                        case TetrominoColor.GREEN:
+                                                drawBrick(offScreen, i, j, Color.GREEN);
+                                                break;
+                                        case TetrominoColor.BLUE:
+                                                drawBrick(offScreen, i, j, Color.BLUE);
+                                                break;
+                                        case TetrominoColor.MAGENTA:
+                                                drawBrick(offScreen, i, j, Color.MAGENTA);
+                                                break;
+                                        case TetrominoColor.PINK:
+                                                drawBrick(offScreen, i, j, Color.PINK);
+                                                break;
+                                        default:
+                                                drawBrick(offScreen, i, j, Color.LIGHT_GRAY);
+                                                break;
+                                }*/
 			}
 		}		
 	}

--- a/src/Shape_L.java
+++ b/src/Shape_L.java
@@ -6,9 +6,9 @@
  * To change this template use File | Settings | File Templates.
  */
 public class Shape_L extends Bricks {
-	public Shape_L() {
-		setColor(6);
-	}
+        public Shape_L() {
+                setColor(TetrominoColor.MAGENTA);
+        }
 
 	protected void init() {
 		oBrick[0].setX(5);

--- a/src/Shape_Line.java
+++ b/src/Shape_Line.java
@@ -7,9 +7,9 @@
  */
 public class Shape_Line extends Bricks {
 	boolean isFlip;
-	public Shape_Line() {
-		setColor(2);
-	}
+        public Shape_Line() {
+                setColor(TetrominoColor.RED);
+        }
 
 	protected void init() {
 		oBrick[0].setX(5);
@@ -21,10 +21,10 @@ public class Shape_Line extends Bricks {
 		oBrick[3].setX(8);
 		oBrick[3].setY(0);
 		isFlip = true;
-		oBrick[0].setColor(2);
-		oBrick[1].setColor(3);
-		oBrick[2].setColor(4);
-		oBrick[3].setColor(5);
+                oBrick[0].setColor(TetrominoColor.RED);
+                oBrick[1].setColor(TetrominoColor.CYAN);
+                oBrick[2].setColor(TetrominoColor.GREEN);
+                oBrick[3].setColor(TetrominoColor.BLUE);
 
 	}
 

--- a/src/Shape_RevL.java
+++ b/src/Shape_RevL.java
@@ -6,9 +6,9 @@
  * To change this template use File | Settings | File Templates.
  */
 public class Shape_RevL extends Bricks {
-	public Shape_RevL() {
-		setColor(7);
-	}
+        public Shape_RevL() {
+                setColor(TetrominoColor.PINK);
+        }
 
 	protected void init() {
 		oBrick[0].setX(7);

--- a/src/Shape_RevT.java
+++ b/src/Shape_RevT.java
@@ -6,9 +6,9 @@
  * To change this template use File | Settings | File Templates.
  */
 public class Shape_RevT extends Bricks {
-	public Shape_RevT() {
-		setColor(3);
-	}
+        public Shape_RevT() {
+                setColor(TetrominoColor.CYAN);
+        }
 
 	protected void init() {
 		oBrick[0].setX(6);

--- a/src/Shape_RevZ.java
+++ b/src/Shape_RevZ.java
@@ -6,9 +6,9 @@
  * To change this template use File | Settings | File Templates.
  */
 public class Shape_RevZ extends Bricks {
-	public Shape_RevZ() {
-		setColor(5);
-	}
+        public Shape_RevZ() {
+                setColor(TetrominoColor.BLUE);
+        }
 
 	protected void init() {
 		oBrick[0].setX(6);

--- a/src/Shape_Square.java
+++ b/src/Shape_Square.java
@@ -6,9 +6,9 @@
  * To change this template use File | Settings | File Templates.
  */
 public class Shape_Square extends Bricks  {
-	public Shape_Square() {
-		setColor(1);
-	}
+        public Shape_Square() {
+                setColor(TetrominoColor.YELLOW);
+        }
 
 	protected void init() {
 		oBrick[0].setX(6);

--- a/src/Shape_Z.java
+++ b/src/Shape_Z.java
@@ -6,9 +6,9 @@
  * To change this template use File | Settings | File Templates.
  */
 public class Shape_Z extends Bricks {
-	public Shape_Z() {
-		setColor(4);
-	}
+        public Shape_Z() {
+                setColor(TetrominoColor.GREEN);
+        }
 
 	protected void init() {
 		oBrick[0].setX(7);

--- a/src/TetrominoColor.java
+++ b/src/TetrominoColor.java
@@ -1,0 +1,13 @@
+public final class TetrominoColor {
+    public static final int YELLOW = 1;
+    public static final int RED = 2;
+    public static final int CYAN = 3;
+    public static final int GREEN = 4;
+    public static final int BLUE = 5;
+    public static final int MAGENTA = 6;
+    public static final int PINK = 7;
+
+    private TetrominoColor() {
+        // Utility class
+    }
+}


### PR DESCRIPTION
## Summary
- centralize block color values in new `TetrominoColor` class
- use the constants in shape classes instead of numeric literals
- reference constants in `Panel`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6848f289a4b08329af3df562c8da7bcf