### PR TITLE
Fix uninitialized score label

### DIFF
--- a/src/Tetris.java
+++ b/src/Tetris.java
@@ -42,9 +42,10 @@ public class Tetris extends JFrame {
 		new Tetris().run();
 	}
 
-	private void setProgram() {
-		oPlayer = new Player(1, this);
-	}
+        private void setProgram() {
+                oPlayer = new Player(1, this);
+                scoreLabel = new JLabel("Score: 0");
+        }
 
         private void setGUI() {
                 oContainer = getContentPane();
@@ -92,9 +93,7 @@ public class Tetris extends JFrame {
         }
 
         public void updateScore() {
-                if (scoreLabel != null) {
-                        scoreLabel.setText("Score: " + oPlayer.getoGameSettings().getScore());
-                }
+                scoreLabel.setText("Score: " + oPlayer.getoGameSettings().getScore());
         }
 
         public void stop() {


### PR DESCRIPTION
## Summary
- initialize `scoreLabel` before configuring the UI
- simplify `updateScore` to always update the label

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684a5ec76fd88329aefc3d9a3790153c